### PR TITLE
Upgrade outwatch dependency and add history api link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,5 @@ GitHub.sublime-settings
 # End of https://www.gitignore.io/api/sbt,scala,bloop,metals,intellij,sublimetext
 
 /.idea/
+
+/outwatch-router/yarn.lock

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Most of this code is adapted from [http4s](http4s.org)'s route parsing and path 
 Add to library dependencies:
 
 ```
-	"com.clovellytech" %%% "outwatch-router" % "0.0.4"
+	"com.clovellytech" %%% "outwatch-router" % "0.0.5"
 ```
 
 See [documentation][doc-root]

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,7 @@ lazy val router  = project
     webpackBundlingMode in fastOptJS := BundlingMode.LibraryOnly(),
     resolvers += "jitpack" at "https://jitpack.io",
     libraryDependencies ++= Seq(
-      "io.github.outwatch" % "outwatch" % "ea240c6d04",
+      "io.github.outwatch" % "outwatch" % "e0f28a8fbb",
       "org.scalatest" %%% "scalatest" % "3.0.5" % Test
     ),
     copyFastOptJS := {

--- a/outwatch-router/src/main/scala/outwatch/router/dsl/C.scala
+++ b/outwatch-router/src/main/scala/outwatch/router/dsl/C.scala
@@ -1,0 +1,13 @@
+package outwatch.router
+package dsl
+
+import outwatch.dom.VDomModifier
+import outwatch.dom.{dsl => O, _}
+
+object C {
+  def a[P](linkHref: String)(attrs: VDomModifier*)(implicit store: RouterStore[P]): BasicVNode =
+    O.a(
+      O.href := linkHref,
+      O.onClick.preventDefault.mapTo(Replace(Path(linkHref))) --> store
+    )(attrs)
+}

--- a/outwatch-router/src/main/scala/outwatch/router/package.scala
+++ b/outwatch-router/src/main/scala/outwatch/router/package.scala
@@ -3,7 +3,7 @@ package outwatch
 import outwatch.dom.VDomModifier
 
 package object router {
-  type RouterStore[P] = ProHandler[Action, RouterState[P]]
+  type RouterStore[P] = ProHandler[Action, (Action, RouterState[P])]
 
   type RouterResolve[P] = PartialFunction[P, VDomModifier]
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,4 +1,4 @@
 object Version{
-  val version = "0.0.4"
+  val version = "0.0.5"
   val scalaVersion = "2.12.8"
 }


### PR DESCRIPTION
Adds a new `a` tag which prevents default and instead sends an action to a router store which has the side effect of updating the history api