### PR TITLE
Fix urlEncode for e.g. german umlauts

### DIFF
--- a/outwatch-router/src/main/scala/outwatch/router/Path.scala
+++ b/outwatch-router/src/main/scala/outwatch/router/Path.scala
@@ -131,7 +131,9 @@ private[router] object UrlCodingUtils {
 
   private val toSkip: Set[Char] = Unreserved ++ "!$&'()*+,;=:/?@"
 
-  private val HexUpperCaseChars: Array[Char] = ('A' to 'F').toArray
+  private val HexUpperCaseChars = (0 until 16).map { i =>
+    Character.toUpperCase(Character.forDigit(i, 16))
+  }
 
   /** Percent-encodes a string.  Depending on the parameters, this method is
     * appropriate for URI or URL form encoding.  Any resulting percent-encodings


### PR DESCRIPTION
Adopted from https://github.com/http4s/http4s/blob/main/core/src/main/scala/org/http4s/internal/UriCoding.scala#L51